### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paazmaya/kitsune-stt/security/code-scanning/1](https://github.com/paazmaya/kitsune-stt/security/code-scanning/1)

To fix the problem, add a `permissions` block defining the minimum required permissions for this workflow. Since the CI job shown only needs to check out code and run standard Rust CI operations (tests, linting, formatting, documentation), it only requires `contents: read`—the minimal permission required to access source code in the repository. Place the `permissions:` block at the top level of the workflow YAML file (just after the `name:` field and above `on:`), which will apply to all jobs in the workflow. No new methods or imports are needed—this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
